### PR TITLE
Upgrade mongodb to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/express": "^4.11.1",
     "@types/jasmine": "2.5.45",
     "@types/lodash": "^4.14.98",
-    "@types/mongodb": "^2.2.18",
+    "@types/mongodb": "^3.0.9",
     "@types/node": "^9.4.0",
     "@types/supertest": "^2.0.4",
     "@types/uuid": "^3.4.3",
@@ -78,7 +78,7 @@
     "debug": "^3.1.0",
     "express": "^4.16.2",
     "lodash": "^4.17.5",
-    "mongodb": "^2.2.33",
+    "mongodb": "^3.0.5",
     "reflect-metadata": "^0.1.12",
     "uuid": "^3.2.1"
   }

--- a/src/core/@model/model.spec.ts
+++ b/src/core/@model/model.spec.ts
@@ -139,7 +139,7 @@ describe('core/@Model', () => {
         try {
           await DefaultCrud.removeAll({});
           await sapi.close();
-          
+
           sapi.deregisterDependencies();
           sapi = null;
           done();
@@ -492,7 +492,7 @@ describe('core/@Model', () => {
               await user.create();
               const result = await user
                 .getCollection()
-                .find({_id: user.id})
+                .find<any>({_id: user.id})
                 .limit(1)
                 .next();
 
@@ -857,7 +857,7 @@ describe('core/@Model', () => {
 
                 const updated = await pud
                   .getCollection()
-                  .find({_id: pud.id})
+                  .find<any>({_id: pud.id})
                   .limit(1)
                   .next();
 

--- a/src/core/@model/model.ts
+++ b/src/core/@model/model.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   CollectionInsertOneOptions,
-  CollectionOptions,
+  CommonOptions,
   Cursor,
   Db,
   DeleteWriteOpResultObject,
@@ -985,10 +985,10 @@ async function getOne(filter: any, project?: any): Promise<any> {
 
 /**
  * @instance Removes the current Model's document from the database.
- * @param options MongoDB CollectionOptions
+ * @param options MongoDB CommonOptions
  * @returns {Promise<DeleteWriteOpResultObject>}
  */
-function remove(options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
+function remove(options?: CommonOptions): Promise<DeleteWriteOpResultObject> {
   const constructor = this.constructor;
   debug.normal(`.remove called for ${(this || {} as any).id}`);
   return constructor.removeById(this.id, options);
@@ -997,10 +997,10 @@ function remove(options?: CollectionOptions): Promise<DeleteWriteOpResultObject>
 /**
  * @static Removes all documents from the database that match the filter criteria.
  * @param filter A MongoDB query.
- * @param options MongoDB CollectionOptions
+ * @param options MongoDB CommonOptions
  * @returns {Promise<DeleteWriteOpResultObject>}
  */
-function removeAll(filter: any, options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
+function removeAll(filter: any, options?: CommonOptions): Promise<DeleteWriteOpResultObject> {
   const col = this.getCollection();
 
   debug.normal(`.removeAll called, dbName: '${this[modelSymbols.dbName]}', found?: ${!!col}, id: %O`,
@@ -1016,10 +1016,10 @@ function removeAll(filter: any, options?: CollectionOptions): Promise<DeleteWrit
 /**
  * @static Removes a specific document from the database by its id.
  * @param id
- * @param options CollectionOptions
+ * @param options CommonOptions
  * @returns {DeleteWriteOpResultObject}
  */
-function removeById(id: any, options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
+function removeById(id: any, options?: CommonOptions): Promise<DeleteWriteOpResultObject> {
   const col = this.getCollection();
 
   if (!(id instanceof ObjectID)) {

--- a/src/core/@model/sapi-model-mixin.ts
+++ b/src/core/@model/sapi-model-mixin.ts
@@ -2,7 +2,7 @@
 import {
   Collection,
   CollectionInsertOneOptions,
-  CollectionOptions,
+  CommonOptions,
   Cursor,
   Db,
   DeleteWriteOpResultObject,
@@ -49,7 +49,7 @@ import {
  * ...
  * }
  *
- * (SuperChicken as any).prototype.remove(filter: any | null, options?: CollectionOptions) => Promise<DeleteWriteOpResultObject> {
+ * (SuperChicken as any).prototype.remove(filter: any | null, options?: CommonOptions) => Promise<DeleteWriteOpResultObject> {
  * ...
  * }
  * </pre>
@@ -78,8 +78,8 @@ export function SapiModelMixin<C extends Constructor<{}>>(base?: C) {
     static getDb: () => Db;
     static getOne: <T>(this: { new (): T }, filter: any, project?: any) => Promise<T>;
 
-    static removeAll: (filter: any, options?: CollectionOptions) => Promise<DeleteWriteOpResultObject>;
-    static removeById: (id: ObjectID, options?: CollectionOptions) => Promise<DeleteWriteOpResultObject>;
+    static removeAll: (filter: any, options?: CommonOptions) => Promise<DeleteWriteOpResultObject>;
+    static removeById: (id: ObjectID, options?: CommonOptions) => Promise<DeleteWriteOpResultObject>;
 
     static sapi: SakuraApi;
     static sapiConfig?: any;
@@ -92,7 +92,7 @@ export function SapiModelMixin<C extends Constructor<{}>>(base?: C) {
     getCollection: () => Collection;
     getDb: () => Db;
 
-    remove: (filter: any | null, options?: CollectionOptions) => Promise<DeleteWriteOpResultObject>;
+    remove: (filter: any | null, options?: CommonOptions) => Promise<DeleteWriteOpResultObject>;
     save: (set?: { [key: string]: any } | null, options?: ReplaceOneOptions) => Promise<UpdateWriteOpResult>;
 
     toDb: (changeSet?: object) => any;

--- a/src/core/@routable/routable.spec.ts
+++ b/src/core/@routable/routable.spec.ts
@@ -1506,7 +1506,7 @@ describe('core/@Routable', () => {
             .then((id) => {
               return User
                 .getCollection()
-                .find({_id: new ObjectID(id)})
+                .find<any>({_id: new ObjectID(id)})
                 .limit(1)
                 .next()
                 .then((result) => {


### PR DESCRIPTION
This doesn't have any breaking API changes, however the mongo upgrade is a major version bump, so that could cause some indirect breaking changes.

### Changes
[**&rarr; MongoDB Release Notes**](https://github.com/mongodb/node-mongodb-native/blob/b8484257e16ab129b5d1614f6c9fbf933846814d/CHANGES_3.0.0.md)

Notably, the connection strings must not be URL encoded:

> Following changes to the MongoDB connection string specification, authentication and hostname details in connection strings must now be URL-encoded. These changes reduce ambiguity in connection strings.
>
> For example, whereas before mongodb://u$ername:pa$$w{}rd@/tmp/mongodb-27017.sock/test would have been a valid connection string (with username u$ername, password pa$$w{}rd, host /tmp/mongodb-27017.sock and auth database test), the connection string for those details would now have to be provided to MongoClient as mongodb://u%24ername:pa%24%24w%7B%7Drd@%2Ftmp%2Fmongodb-27017.sock/test.

There is also a small edge case the if you are using the `find()` method on a collection, you'll need to specify the type at the calling site:

```ts
// before
Model.getCollection()
  .find({ _id: 'someid' })
  .limit(1)
  .next();

// after
Model.getCollection()
  .find<any>({ _id: 'someid' })
  .limit(1)
  .next();
```
