### PR TITLE
Issue/233 from-db.ts - Clear element object in between iterations

### DIFF
--- a/src/core/@model/model-operators/from-db.spec.ts
+++ b/src/core/@model/model-operators/from-db.spec.ts
@@ -56,7 +56,7 @@ describe('@Model.fromDb', () => {
       expect(result.val).toBe(777);
     });
 
-    it('returns an object of the correct instaceOf', () => {
+    it('returns an object of the correct instanceOf', () => {
       const result = Test.fromDb({});
       expect(result instanceof Test).toBe(true);
     });
@@ -252,6 +252,9 @@ describe('@Model.fromDb', () => {
 
         @Db({field: 'addr', model: Address})
         address = new Address();
+
+        @Db()
+        tag: string;
       }
 
       @Model()
@@ -468,7 +471,7 @@ describe('@Model.fromDb', () => {
           expect(result.leads.length).toBe(0);
         });
 
-        it('maps an array of sub documents from the DB to a resulting array of type model', () => {
+        fit('maps an array of sub documents from the DB to a resulting array of type model', () => {
 
           const leadSubDocs = [
             {
@@ -479,7 +482,8 @@ describe('@Model.fromDb', () => {
                 st: '123',
                 z: '90277'
               },
-              n: '1'
+              n: '1',
+              tag: 'abc'
             },
             {
               addr: {
@@ -513,6 +517,9 @@ describe('@Model.fromDb', () => {
           expect((result.leads[1].address || {} as any).state).toBe(leadSubDocs[1].addr.s);
           expect((result.leads[1].address || {} as any).street).toBe(leadSubDocs[1].addr.st);
           expect((result.leads[1].address || {} as any).zip).toBe(leadSubDocs[1].addr.z);
+
+          expect(result.leads[0].tag).toBe(leadSubDocs[0].tag);
+          expect(result.leads[1].tag).toBeUndefined('Undefined sub-document field should not be defined');
 
         });
       });

--- a/src/core/@model/model-operators/from-db.spec.ts
+++ b/src/core/@model/model-operators/from-db.spec.ts
@@ -471,7 +471,7 @@ describe('@Model.fromDb', () => {
           expect(result.leads.length).toBe(0);
         });
 
-        fit('maps an array of sub documents from the DB to a resulting array of type model', () => {
+        it('maps an array of sub documents from the DB to a resulting array of type model', () => {
 
           const leadSubDocs = [
             {

--- a/src/core/@model/model-operators/from-db.ts
+++ b/src/core/@model/model-operators/from-db.ts
@@ -54,6 +54,7 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
       return source;
     }
 
+    console.log('=================='.zebra.green, JSON.stringify(target, null, 2).green);
     const dbOptionsByFieldName: Map<string, IDbOptions>
       = Reflect.getMetadata(dbSymbols.dbByFieldName, target) || new Map<string, IDbOptions>();
 
@@ -63,6 +64,7 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
 
       // convert the DB key name to the Model key name
       const mapper = map(key, source[key], dbOptionsByFieldName);
+      if (key === 'tag') console.log('================== mapper'.cyan, JSON.stringify(mapper, null, 2).cyan);
       const model = mapper.model;
 
       let nextTarget;
@@ -73,7 +75,9 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
       } catch (err) {
         throw new Error(`Model '${modelName}' has a property '${key}' that defines its model with a value that`
           + ` cannot be constructed`);
-      }
+        }
+
+      console.log('================== 111111'.zebra.green, JSON.stringify(target, null, 2).green);
 
       if (model || shouldRecurse(source[key])) {
 
@@ -87,12 +91,13 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
             const values = [];
 
             for (const src of source[key]) {
+              console.log('==================src'.cyan, src);
+              nextTarget = (model);
               values.push(Object.assign(new model(), mapDbToModel(src, nextTarget, map)));
             }
             value = values;
 
           } else {
-
             value = mapDbToModel(source[key], nextTarget, map, ++depth);
 
             if (model) {
@@ -103,20 +108,23 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
               }
             }
           }
-
+          console.log('================== >>>>>>>'.cyan, mapper.newKey);
           target[mapper.newKey] = value;
         }
 
       } else {
         // otherwise, map a property that has a primitive value or an ObjectID value
         if (mapper.newKey !== undefined) {
+          console.log('================== %%%%%%'.cyan, `assigning ${source[key]} to ${mapper.newKey}`);
           target[mapper.newKey] = (source[key] !== undefined && source[key] !== null)
             ? source[key]
             : nextTarget; // resolves issue #94
         }
       }
+      console.log('================== 222222'.zebra.green, JSON.stringify(target, null, 2).green);
     }
 
+    if (!!target.order) console.log('=================='.zebra.red, JSON.stringify(target, null, 2).red);
     return target;
   }
 

--- a/src/core/@model/model-operators/from-db.ts
+++ b/src/core/@model/model-operators/from-db.ts
@@ -54,7 +54,6 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
       return source;
     }
 
-    console.log('=================='.zebra.green, JSON.stringify(target, null, 2).green);
     const dbOptionsByFieldName: Map<string, IDbOptions>
       = Reflect.getMetadata(dbSymbols.dbByFieldName, target) || new Map<string, IDbOptions>();
 
@@ -64,7 +63,6 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
 
       // convert the DB key name to the Model key name
       const mapper = map(key, source[key], dbOptionsByFieldName);
-      if (key === 'tag') console.log('================== mapper'.cyan, JSON.stringify(mapper, null, 2).cyan);
       const model = mapper.model;
 
       let nextTarget;
@@ -76,8 +74,6 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
         throw new Error(`Model '${modelName}' has a property '${key}' that defines its model with a value that`
           + ` cannot be constructed`);
         }
-
-      console.log('================== 111111'.zebra.green, JSON.stringify(target, null, 2).green);
 
       if (model || shouldRecurse(source[key])) {
 
@@ -91,9 +87,10 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
             const values = [];
 
             for (const src of source[key]) {
-              console.log('==================src'.cyan, src);
-              nextTarget = (model);
               values.push(Object.assign(new model(), mapDbToModel(src, nextTarget, map)));
+              nextTarget = (model)
+                  ? Object.assign(new model(), target[mapper.newKey])
+                  : target[mapper.newKey];
             }
             value = values;
 
@@ -108,23 +105,19 @@ export function fromDb(json: any, options?: IFromDbOptions): object {
               }
             }
           }
-          console.log('================== >>>>>>>'.cyan, mapper.newKey);
           target[mapper.newKey] = value;
         }
 
       } else {
         // otherwise, map a property that has a primitive value or an ObjectID value
-        if (mapper.newKey !== undefined) {
-          console.log('================== %%%%%%'.cyan, `assigning ${source[key]} to ${mapper.newKey}`);
+          if (mapper.newKey !== undefined) {
           target[mapper.newKey] = (source[key] !== undefined && source[key] !== null)
             ? source[key]
             : nextTarget; // resolves issue #94
         }
       }
-      console.log('================== 222222'.zebra.green, JSON.stringify(target, null, 2).green);
     }
 
-    if (!!target.order) console.log('=================='.zebra.red, JSON.stringify(target, null, 2).red);
     return target;
   }
 


### PR DESCRIPTION
The object used to build the elements in an array was being reused, and not cleared in between iterations causing any previous properties not overwritten to persist to the next element. Added init after element push().